### PR TITLE
Use printf instead of echo to parse short option

### DIFF
--- a/functions/argu.fish
+++ b/functions/argu.fish
@@ -41,7 +41,7 @@ function argu -d "Parse command options"
       # Match a short or long single option.
       case '--*' '-?'
         if contains -- $argv[1] $options
-          echo -E "$argv[1]"
+          printf "$argv[1]\n"
         else if contains -- $argv[1]: $options
           # Option must have a value.
           if begin; not set -q argv[2]; or expr "$argv[2]" : '-.*' > /dev/null; end

--- a/functions/argu.fish
+++ b/functions/argu.fish
@@ -41,7 +41,7 @@ function argu -d "Parse command options"
       # Match a short or long single option.
       case '--*' '-?'
         if contains -- $argv[1] $options
-          printf "$argv[1]\n"
+          printf "%s\n" $argv[1]
         else if contains -- $argv[1]: $options
           # Option must have a value.
           if begin; not set -q argv[2]; or expr "$argv[2]" : '-.*' > /dev/null; end


### PR DESCRIPTION
Hi, thank you for the good plugin!
This is the nicest option parser for fish-shell.

I fixed short option parsing. In the current version, options -e,  -n, -s, -E are not parsed because they are options of `echo` command.

```fish
argu e -- -e # output is ''
```